### PR TITLE
Change minimum city distance to 3

### DIFF
--- a/jsons/ModOptions.json
+++ b/jsons/ModOptions.json
@@ -10,8 +10,8 @@
 		"Suppress warning [Military Engineer can place improvement Remove Toxic Waste which has no stats, preventing unit automation!]"
 	],
 	"constants": {
-		"minimalCityDistance": 4,
-		"minimalCityDistanceOnDifferentContinents": 4,
+		"minimalCityDistance": 3,
+		"minimalCityDistanceOnDifferentContinents": 3,
 		"ancientRuinCountMultiplier": 0.04,
 		"religionLimitBase": 0,
 		"religionLimitMultiplier": 1,


### PR DESCRIPTION
The minimum city distance of four is simply inconvenient and obstructive. This change reverts the minimum city distance to three. The AI is more annoying when they settle inconveniently and not let you access large chunks of terrain compared to when they settle near you.